### PR TITLE
log: Make log forwarder work for HTTPS endpoint

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -200,6 +200,11 @@ func (l *LogForwarder) initWSConnection() error {
 		return err
 	}
 	tsuruUrl.Path = "/logs"
+	if tsuruUrl.Scheme == "https" {
+		tsuruUrl.Scheme = "wss"
+	} else {
+		tsuruUrl.Scheme = "ws"
+	}
 	forwardChan, quitChan, err := processMessages(&wsForwarder{
 		url:   tsuruUrl.String(),
 		token: l.TsuruToken,

--- a/log/log.go
+++ b/log/log.go
@@ -199,9 +199,9 @@ func (l *LogForwarder) initWSConnection() error {
 	if err != nil {
 		return err
 	}
-	wsUrl := fmt.Sprintf("ws://%s/logs", tsuruUrl.Host)
+	tsuruUrl.Path = "/logs"
 	forwardChan, quitChan, err := processMessages(&wsForwarder{
-		url:   wsUrl,
+		url:   tsuruUrl.String(),
 		token: l.TsuruToken,
 	})
 	if err != nil {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -114,11 +114,18 @@ func (s *S) TestLogForwarderStartDockerAppName(c *check.C) {
 	c.Assert(buffer[:n], check.DeepEquals, expected)
 }
 
-func (s *S) TestLogForwarderWSForwarder(c *check.C) {
+func (s *S) TestLogForwarderWSForwarderHTTP(c *check.C) {
+	testLogForwarderWSForwarder(s, c, httptest.NewServer)
+}
+
+func testLogForwarderWSForwarder(
+	s *S, c *check.C,
+	serverFunc func(handler http.Handler) *httptest.Server,
+) {
 	var body bytes.Buffer
 	var serverMut sync.Mutex
 	var req *http.Request
-	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+	srv := serverFunc(websocket.Handler(func(ws *websocket.Conn) {
 		serverMut.Lock()
 		defer serverMut.Unlock()
 		req = ws.Request()

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -118,6 +118,10 @@ func (s *S) TestLogForwarderWSForwarderHTTP(c *check.C) {
 	testLogForwarderWSForwarder(s, c, httptest.NewServer)
 }
 
+func (s *S) TestLogForwarderWSForwarderHTTPS(c *check.C) {
+	testLogForwarderWSForwarder(s, c, httptest.NewTLSServer)
+}
+
 func testLogForwarderWSForwarder(
 	s *S, c *check.C,
 	serverFunc func(handler http.Handler) *httptest.Server,


### PR DESCRIPTION
When the Tsuru endpoint is HTTPS (rather than HTTP) then the URL scheme
should be `wss://` (rather than `ws://`). Otherwise bs tries to connect
using HTTP to an HTTPS endpoint and reports the following error:

```
2015/08/04 13:24:16 Unable to initialize log forwarder: bad status
```

Paired with @keymon
