### PR TITLE
logs: forwards non app logs to non tsuru backends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,13 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+FROM golang:1.9.0 as builder
+
+COPY . /go/src/github.com/tsuru/bs
+WORKDIR /go/src/github.com/tsuru/bs
+RUN make build
+
 FROM alpine:3.2
 RUN  apk update && apk add conntrack-tools ca-certificates tzdata && rm -rf /var/cache/apk/*
-ADD  bs /bin/bs
+COPY --from=builder /go/src/github.com/tsuru/bs/bs /bin/bs
 ENTRYPOINT ["/bin/bs"]

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ check-format:
 run:
 	go run main.go
 
-_build:
+build:
 	go build -ldflags "-linkmode external -extldflags -static"
 
-publish-local: _build
+publish-local:
 	docker build -t 127.0.0.1:5000/tsuru/bs .
 	docker push 127.0.0.1:5000/tsuru/bs
 

--- a/container/container.go
+++ b/container/container.go
@@ -19,9 +19,10 @@ import (
 var (
 	ErrTsuruVariablesNotFound = errors.New("could not find wanted envs")
 
-	hexRegex          = regexp.MustCompile(`(?i)^[a-f0-9]+$`)
-	processNameLabels = []string{"bs.tsuru.io/log-app-name", "log-app-name", "io.kubernetes.pod.name"}
-	appNameLabels     = []string{"bs.tsuru.io/log-process-name", "log-process-name", "io.kubernetes.container.name"}
+	hexRegex = regexp.MustCompile(`(?i)^[a-f0-9]+$`)
+
+	appNameLabels     = []string{"bs.tsuru.io/log-app-name", "log-app-name", "io.kubernetes.container.name"}
+	processNameLabels = []string{"bs.tsuru.io/log-process-name", "log-process-name", "io.kubernetes.pod.name"}
 )
 
 const containerIDTrimSize = 12

--- a/container/container.go
+++ b/container/container.go
@@ -30,16 +30,10 @@ type InfoClient struct {
 
 type Container struct {
 	docker.Container
-	client      *InfoClient
-	AppName     string
-	ProcessName string
-}
-
-func (c *Container) ShortHostName() string {
-	if hexRegex.MatchString(c.Config.Hostname) && len(c.Config.Hostname) > containerIDTrimSize {
-		return c.Config.Hostname[:containerIDTrimSize]
-	}
-	return c.Config.Hostname
+	client        *InfoClient
+	AppName       string
+	ProcessName   string
+	ShortHostname string
 }
 
 const (
@@ -129,6 +123,10 @@ func (c *InfoClient) getContainer(containerId string, useCache bool) (*Container
 				*v = env[len(k):]
 			}
 		}
+	}
+	contData.ShortHostname = contData.Config.Hostname
+	if hexRegex.MatchString(contData.Config.Hostname) && len(contData.Config.Hostname) > containerIDTrimSize {
+		contData.ShortHostname = contData.Config.Hostname[:containerIDTrimSize]
 	}
 	c.containerCache.Add(containerId, &contData)
 	return &contData, nil

--- a/container/container.go
+++ b/container/container.go
@@ -20,7 +20,7 @@ var (
 	ErrTsuruVariablesNotFound = errors.New("could not find wanted envs")
 
 	hexRegex          = regexp.MustCompile(`(?i)^[a-f0-9]+$`)
-	processNameLabels = []string{"bs.tsuru.io/log-app-name", "log-name", "io.kubernetes.pod.name"}
+	processNameLabels = []string{"bs.tsuru.io/log-app-name", "log-app-name", "io.kubernetes.pod.name"}
 	appNameLabels     = []string{"bs.tsuru.io/log-process-name", "log-process-name", "io.kubernetes.container.name"}
 )
 

--- a/log/gelfforwarder.go
+++ b/log/gelfforwarder.go
@@ -55,9 +55,6 @@ func (b *gelfBackend) initialize() error {
 }
 
 func (b *gelfBackend) sendMessage(parts *rawLogParts, appName, processName, container string) {
-	if len(container) > containerIDTrimSize {
-		container = container[:containerIDTrimSize]
-	}
 	level := gelf.LOG_INFO
 	if s, err := strconv.Atoi(string(parts.priority)); err == nil {
 		if int32(s)&gelf.LOG_ERR == gelf.LOG_ERR {

--- a/log/log.go
+++ b/log/log.go
@@ -221,13 +221,12 @@ func (l *LogForwarder) Handle(logParts format.LogParts, _ int64, err error) {
 		bslog.Debugf("[log forwarder] error getting container %v for msg %v", contStr, parts)
 		return
 	}
-	contID := contData.ShortHostName()
 	if contData.AppName == "" {
-		l.handleGeneral(parts, contData, contID)
+		l.handleGeneral(parts, contData)
 		return
 	}
 	for _, backend := range l.backends {
-		backend.sendMessage(parts, contData.AppName, contData.ProcessName, contID)
+		backend.sendMessage(parts, contData.AppName, contData.ProcessName, contData.ShortHostname)
 	}
 }
 
@@ -235,7 +234,7 @@ var processNameLabels = []string{"bs.tsuru.io/log-app-name", "log-name", "io.kub
 var appNameLabels = []string{"bs.tsuru.io/log-process-name", "log-process-name", "io.kubernetes.container.name"}
 
 // handleGeneral handles logging for non tsuru app containers
-func (l *LogForwarder) handleGeneral(logParts *rawLogParts, cont *container.Container, contStr string) {
+func (l *LogForwarder) handleGeneral(logParts *rawLogParts, cont *container.Container) {
 	name, ok := cont.GetLabelAny(appNameLabels...)
 	if !ok {
 		name = cont.Name
@@ -248,6 +247,6 @@ func (l *LogForwarder) handleGeneral(logParts *rawLogParts, cont *container.Cont
 		if _, ok := backend.(*tsuruBackend); ok {
 			continue
 		}
-		backend.sendMessage(logParts, name, process, cont.Config.Hostname)
+		backend.sendMessage(logParts, name, process, cont.ShortHostname)
 	}
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -740,7 +740,7 @@ func (s *S) TestLogForwarderHandleNonTsuruApp(c *check.C) {
 	udpConn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	n, err := udpConn.Read(buffer)
 	c.Assert(err, check.IsNil)
-	c.Assert(string(buffer[:n]), check.Equals, fmt.Sprintf("<30>Jun  5 13:13:47 %s big-sibling[%s]: mymsg\n", cont.ShortHostName(), contID))
+	c.Assert(string(buffer[:n]), check.Equals, fmt.Sprintf("<30>Jun  5 13:13:47 %s big-sibling[%s]: mymsg\n", cont.ShortHostname, contID))
 }
 
 func (s *S) TestLogForwarderHandleNonTsuruAppKubernetesLabels(c *check.C) {
@@ -774,7 +774,7 @@ func (s *S) TestLogForwarderHandleNonTsuruAppKubernetesLabels(c *check.C) {
 	udpConn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	n, err := udpConn.Read(buffer)
 	c.Assert(err, check.IsNil)
-	c.Assert(string(buffer[:n]), check.Equals, fmt.Sprintf("<30>Jun  5 13:13:47 %s my-cont[my-pod]: mymsg\n", cont.ShortHostName()))
+	c.Assert(string(buffer[:n]), check.Equals, fmt.Sprintf("<30>Jun  5 13:13:47 %s my-cont[my-pod]: mymsg\n", cont.ShortHostname))
 }
 
 func startReceiver(expected int, ch chan struct{}, data ...chan string) net.Listener {

--- a/log/syslogforwarder.go
+++ b/log/syslogforwarder.go
@@ -112,17 +112,13 @@ func (b *syslogBackend) sendMessage(parts *rawLogParts, appName, processName, co
 	if lenSyslogs == 0 {
 		return
 	}
-	contID := parts.container
-	if len(contID) > containerIDTrimSize {
-		contID = contID[:containerIDTrimSize]
-	}
 	buffer := b.bufferPool.Get().([]byte)[:0]
 	buffer = append(buffer, '<')
 	buffer = append(buffer, parts.priority...)
 	buffer = append(buffer, '>')
 	buffer = append(buffer, parts.ts.In(b.syslogLocation).Format(time.Stamp)...)
 	buffer = append(buffer, ' ')
-	buffer = append(buffer, contID...)
+	buffer = append(buffer, container...)
 	buffer = append(buffer, ' ')
 	buffer = append(buffer, appName...)
 	buffer = append(buffer, '[')

--- a/log/wsforwarder.go
+++ b/log/wsforwarder.go
@@ -91,9 +91,6 @@ func (b *tsuruBackend) initialize() error {
 }
 
 func (b *tsuruBackend) sendMessage(parts *rawLogParts, appName, processName, container string) {
-	if len(container) > containerIDTrimSize {
-		container = container[:containerIDTrimSize]
-	}
 	msg := &app.Applog{
 		Date:    parts.ts,
 		AppName: appName,

--- a/metric/backend.go
+++ b/metric/backend.go
@@ -24,14 +24,17 @@ func NewContainerInfo(container *container.Container) ContainerInfo {
 	if container.Name != "" {
 		name = container.Name[1:]
 	}
-	return ContainerInfo{
+	info := ContainerInfo{
 		Name:     name,
 		Image:    container.Config.Image,
-		Hostname: container.Config.Hostname,
-		Process:  container.ProcessName,
-		App:      container.AppName,
+		Hostname: container.ShortHostname,
 		Labels:   container.Config.Labels,
 	}
+	if container.TsuruApp {
+		info.Process = container.ProcessName
+		info.App = container.AppName
+	}
+	return info
 }
 
 type HostInfo struct {

--- a/metric/reporter_test.go
+++ b/metric/reporter_test.go
@@ -29,11 +29,13 @@ func (s *S) SetUpTest(c *check.C) {
 func (s *S) createContainer() container.Container {
 	return container.Container{
 		Container: docker.Container{
-			Config:          &docker.Config{Hostname: "afdb3737ff"},
+			Config:          &docker.Config{},
 			NetworkSettings: &docker.NetworkSettings{IPAddress: "172.17.0.27"},
 		},
-		AppName:     "myapp",
-		ProcessName: "myprocess",
+		ShortHostname: "afdb3737ff",
+		AppName:       "myapp",
+		ProcessName:   "myprocess",
+		TsuruApp:      true,
 	}
 }
 


### PR DESCRIPTION
With this PR, logs from containers without tsuru environment variables
will also be forwarded to every backend expect for tsuru's.

The output may be controlled by some specific labels (support kubernetes
labels out of the box), falling back to the container name and ID.
```
BenchmarkMessagesBroadcastNonAppContainer-4   	  200000	      9934 ns/op	     429 B/op	       7 allocs/op
BenchmarkMessagesBroadcast-4                  	  100000	     11795 ns/op	     719 B/op	      10 allocs/op
BenchmarkMessagesBroadcastWaitTsuru-4         	  200000	      8324 ns/op	     448 B/op	       6 allocs/op
```