### PR TITLE
log: add timestamp do gelf message

### DIFF
--- a/log/gelfforwarder.go
+++ b/log/gelfforwarder.go
@@ -71,6 +71,7 @@ func (b *gelfBackend) sendMessage(parts *rawLogParts, appName, processName, cont
 			"_pid": processName,
 		},
 		RawExtra: b.extra,
+		TimeUnix: float64(time.Now().UnixNano()) / float64(time.Second),
 	}
 	select {
 	case b.msgCh <- msg:


### PR DESCRIPTION
Related to the issue #29 , this code change will add a timestamp to the log message, with decimal places to increase the precision.