### PR TITLE
 log: performance improvements in gelf field parsing

### DIFF
--- a/log/gelfforwarder.go
+++ b/log/gelfforwarder.go
@@ -26,9 +26,8 @@ type gelfBackend struct {
 	nextNotify      *time.Timer
 }
 
-func (b *gelfBackend) initialize() error {
+func (b *gelfBackend) setup() {
 	b.chunkSize = config.IntEnvOrDefault(gelf.ChunkSize, "LOG_GELF_CHUNK_SIZE")
-	bufferSize := config.IntEnvOrDefault(config.DefaultBufferSize, "LOG_GELF_BUFFER_SIZE", "LOG_BUFFER_SIZE")
 	b.host = config.StringEnvOrDefault("localhost:12201", "LOG_GELF_HOST")
 	extra := config.StringEnvOrDefault("", "LOG_GELF_EXTRA_TAGS")
 	if extra != "" {
@@ -48,6 +47,11 @@ func (b *gelfBackend) initialize() error {
 		"uri",
 	}, "LOG_GELF_FIELDS_WHITELIST")
 	b.nextNotify = time.NewTimer(0)
+}
+
+func (b *gelfBackend) initialize() error {
+	b.setup()
+	bufferSize := config.IntEnvOrDefault(config.DefaultBufferSize, "LOG_GELF_BUFFER_SIZE", "LOG_BUFFER_SIZE")
 	var err error
 	b.msgCh, b.quitCh, err = processMessages(b, bufferSize)
 	if err != nil {

--- a/log/gelfforwarder_test.go
+++ b/log/gelfforwarder_test.go
@@ -1,0 +1,125 @@
+package log
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/Graylog2/go-gelf/gelf"
+	"github.com/tsuru/bs/bslog"
+)
+
+func newBackend(t testing.TB) *gelfBackend {
+	bslog.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+	b := &gelfBackend{}
+	b.setup()
+	return b
+}
+
+func BenchmarkGelfBackendParseFieldsNoFields(b *testing.B) {
+	b.StopTimer()
+	backend := newBackend(b)
+	msg := &gelf.Message{
+		Short: "no field to parse with a modest size log message half full of stuff in it",
+		Extra: map[string]interface{}{},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		backend.parseFields(msg)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkGelfBackendInvalidFields(b *testing.B) {
+	b.StopTimer()
+	backend := newBackend(b)
+	msg := &gelf.Message{
+		Short: "invalid fields to parse invalid1=a invalid2=b invalid3=c in4=d inva=EMERG",
+		Extra: map[string]interface{}{},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		backend.parseFields(msg)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkGelfBackendValidFields(b *testing.B) {
+	b.StopTimer()
+	backend := newBackend(b)
+	msg := &gelf.Message{
+		Short: "w fields request_id=a request_time=1 request_uri=/ status=200 level=EMERG",
+		Extra: map[string]interface{}{},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		backend.parseFields(msg)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkGelfBackendHugeValidFields(b *testing.B) {
+	b.StopTimer()
+	backend := newBackend(b)
+	msg := &gelf.Message{
+		Short: "my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields request_id=a request_time=1 request_uri=/ status=200 method=GET " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields ",
+		Extra: map[string]interface{}{},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		backend.parseFields(msg)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkGelfBackendHugeValidFieldsBigWhitelist(b *testing.B) {
+	os.Setenv("LOG_GELF_FIELDS_WHITELIST", "request_id,request_time,request_uri,status,method,uri,type,uid,request_size,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t")
+	defer os.Unsetenv("LOG_GELF_FIELDS_WHITELIST")
+	b.StopTimer()
+	backend := newBackend(b)
+	msg := &gelf.Message{
+		Short: "my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields request_id=a request_time=1 request_uri=/ status=200 method=GET " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields " +
+			"my big message with many fields my big message with many fields my big message with many fields ",
+		Extra: map[string]interface{}{},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		backend.parseFields(msg)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkGelfBackendHugeInvalid(b *testing.B) {
+	os.Setenv("LOG_GELF_FIELDS_WHITELIST", "request_id,request_time,request_uri,status,method,uri,type,uid,request_size,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t")
+	defer os.Unsetenv("LOG_GELF_FIELDS_WHITELIST")
+	b.StopTimer()
+	backend := newBackend(b)
+	msg := &gelf.Message{
+		Short: "mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"mybigmessagewithmanyfieldsmybigmessagewithmanyfieldsmybigmessagewithmanyfields" +
+			"a=a",
+		Extra: map[string]interface{}{},
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		backend.parseFields(msg)
+	}
+	b.StopTimer()
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -840,7 +840,7 @@ func BenchmarkMessagesWaitOneSyslogAddress(b *testing.B) {
 	<-done[0]
 	b.StopTimer()
 	lf.server.Kill()
-	lf.Wait()
+	lf.stopWait()
 }
 
 func BenchmarkMessagesWaitTwoSyslogAddresses(b *testing.B) {
@@ -880,7 +880,7 @@ func BenchmarkMessagesWaitTwoSyslogAddresses(b *testing.B) {
 	<-done[1]
 	b.StopTimer()
 	lf.server.Kill()
-	lf.Wait()
+	lf.stopWait()
 }
 
 func BenchmarkMessagesBroadcastNonAppContainer(b *testing.B) {
@@ -1132,7 +1132,7 @@ func (s *S) TestGelfForwarderParseExtraTags(c *check.C) {
 	conn, err := net.Dial("udp", "127.0.0.1:59317")
 	c.Assert(err, check.IsNil)
 	defer conn.Close()
-	msg := []byte(fmt.Sprintf("<30>2015-06-05T16:13:47Z myhost docker/%s: mymsg request_id=xdsakj invalid_field=sklsakl status=100\tmethod=get myurl.com?uri=ignored\n", s.id))
+	msg := []byte(fmt.Sprintf("<30>2015-06-05T16:13:47Z myhost docker/%s: foo mymsg request_id=xdsakj invalid_field=sklsakl status=100\tmethod=get myurl.com?uri=ignored\n", s.id))
 	_, err = conn.Write(msg)
 	c.Assert(err, check.IsNil)
 
@@ -1141,7 +1141,7 @@ func (s *S) TestGelfForwarderParseExtraTags(c *check.C) {
 	c.Assert(gelfMsg, check.Not(check.IsNil))
 	c.Assert(gelfMsg.Version, check.Equals, "1.1")
 	c.Assert(gelfMsg.Host, check.Equals, s.idShort)
-	c.Assert(gelfMsg.Short, check.Equals, "mymsg request_id=xdsakj invalid_field=sklsakl status=100\tmethod=get myurl.com?uri=ignored")
+	c.Assert(gelfMsg.Short, check.Equals, "foo mymsg request_id=xdsakj invalid_field=sklsakl status=100\tmethod=get myurl.com?uri=ignored")
 	c.Assert(gelfMsg.Level, check.Equals, int32(gelf.LOG_INFO))
 	c.Assert(gelfMsg.Extra, check.DeepEquals, map[string]interface{}{
 		"_app":        "coolappname",


### PR DESCRIPTION
```
name                                      old time/op    new time/op    delta
GelfBackendParseFieldsNoFields-4            12.7ns ± 1%     9.1ns ± 1%  -28.10%  (p=0.002 n=6+6)
GelfBackendInvalidFields-4                   417ns ± 2%     218ns ± 1%  -47.72%  (p=0.000 n=6+5)
GelfBackendValidFields-4                    1.11µs ± 0%    0.60µs ± 1%  -46.04%  (p=0.002 n=6+6)
GelfBackendHugeValidFields-4                2.09µs ± 1%    0.65µs ± 0%  -69.10%  (p=0.016 n=5+4)
GelfBackendHugeValidFieldsBigWhitelist-4    8.47µs ± 2%    0.71µs ± 6%  -91.61%  (p=0.002 n=6+6)
GelfBackendHugeInvalid-4                    9.56µs ± 1%    0.59µs ± 1%  -93.80%  (p=0.002 n=6+6)

name                                      old alloc/op   new alloc/op   delta
GelfBackendParseFieldsNoFields-4             0.00B          0.00B          ~     (all equal)
GelfBackendInvalidFields-4                   0.00B          0.00B          ~     (all equal)
GelfBackendValidFields-4                      120B ± 0%       64B ± 0%  -46.67%  (p=0.002 n=6+6)
GelfBackendHugeValidFields-4                  144B ± 0%       80B ± 0%  -44.44%  (p=0.002 n=6+6)
GelfBackendHugeValidFieldsBigWhitelist-4      144B ± 0%       80B ± 0%  -44.44%  (p=0.002 n=6+6)
GelfBackendHugeInvalid-4                     0.00B          0.00B          ~     (all equal)

name                                      old allocs/op  new allocs/op  delta
GelfBackendParseFieldsNoFields-4              0.00           0.00          ~     (all equal)
GelfBackendInvalidFields-4                    0.00           0.00          ~     (all equal)
GelfBackendValidFields-4                      8.00 ± 0%      4.00 ± 0%  -50.00%  (p=0.002 n=6+6)
GelfBackendHugeValidFields-4                  10.0 ± 0%       5.0 ± 0%  -50.00%  (p=0.002 n=6+6)
GelfBackendHugeValidFieldsBigWhitelist-4      10.0 ± 0%       5.0 ± 0%  -50.00%  (p=0.002 n=6+6)
GelfBackendHugeInvalid-4                      0.00           0.00          ~     (all equal)
```