### PR TITLE
Don't report isolated containers to Tsuru

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -177,8 +177,8 @@ func (c *Container) HasEnvs(requiredEnvs []string) bool {
 }
 
 func (c *Container) IsIsolated() bool {
-	_, isIsolated := c.GetLabelAny(labelIsIsolated)
-	return isIsolated
+	isIsolated, ok := c.GetLabelAny(labelIsIsolated)
+	return ok && isIsolated == "true"
 }
 
 // GetLabelAny returns the first label value that exists with given names

--- a/container/container.go
+++ b/container/container.go
@@ -23,7 +23,10 @@ var (
 	processNameLabels = []string{"bs.tsuru.io/log-process-name", "log-process-name", "io.kubernetes.pod.name"}
 )
 
-const containerIDTrimSize = 12
+const (
+	containerIDTrimSize = 12
+	labelIsIsolated     = "is-isolated-run"
+)
 
 type InfoClient struct {
 	endpoint       string
@@ -171,6 +174,11 @@ func (c *Container) HasEnvs(requiredEnvs []string) bool {
 		}
 	}
 	return true
+}
+
+func (c *Container) IsIsolated() bool {
+	_, isIsolated := c.GetLabelAny(labelIsIsolated)
+	return isIsolated
 }
 
 // GetLabelAny returns the first label value that exists with given names

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -160,14 +160,17 @@ func (S) TestContainerHasEnvs(c *check.C) {
 
 func (S) TestContainerIsIsolated(c *check.C) {
 	dockerServer, err := dTesting.NewServer("127.0.0.1:0", nil, nil)
-	id1 := createContainer(c, dockerServer.URL(), []string{"TSURU_APPNAME=coolappname"}, map[string]string{"is-isolated-run": "true"}, "withLabels")
-	id2 := createContainer(c, dockerServer.URL(), []string{"TSURU_APPNAME=coolappname"}, nil, "withoutLabels")
+	id1 := createContainer(c, dockerServer.URL(), []string{"TSURU_APPNAME=coolappname"}, map[string]string{"is-isolated-run": "true"}, "withTrueLabel")
+	id2 := createContainer(c, dockerServer.URL(), []string{"TSURU_APPNAME=coolappname"}, map[string]string{"is-isolated-run": "false"}, "withFalseLabel")
+	id3 := createContainer(c, dockerServer.URL(), []string{"TSURU_APPNAME=coolappname"}, nil, "withoutLabel")
 	c.Assert(err, check.IsNil)
 	client, err := NewClient(dockerServer.URL())
 	c.Assert(err, check.IsNil)
 	cont1, err := client.GetAppContainer(id1, false)
 	cont2, err := client.GetAppContainer(id2, false)
+	cont3, err := client.GetAppContainer(id3, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(cont1.IsIsolated(), check.Equals, true)
 	c.Assert(cont2.IsIsolated(), check.Equals, false)
+	c.Assert(cont3.IsIsolated(), check.Equals, false)
 }

--- a/status/status.go
+++ b/status/status.go
@@ -177,6 +177,9 @@ func (r *Reporter) retrieveContainerStatuses(containers []docker.APIContainers) 
 			bslog.Errorf("[status reporter] failed to inspect container %q (%s): %s", c.ID, name, err)
 			continue
 		}
+		if cont != nil && cont.IsIsolated() {
+			continue
+		}
 		if cont.Container.State.Restarting ||
 			cont.Container.State.Dead ||
 			cont.Container.State.RemovalInProgress {

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -45,6 +45,8 @@ func (s S) TestReportStatus(c *check.C) {
 		{name: "x4", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}}, state: docker.State{Running: true}},
 		{name: "x5", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/"}}, state: docker.State{Running: false, ExitCode: 2}},
 		{name: "x6", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}}, state: docker.State{Running: false}},
+		{name: "x7", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}, Labels: map[string]string{"is-isolated-run": "true"}}, state: docker.State{Running: true}},
+		{name: "x8", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}, Labels: map[string]string{"is-isolated-run": "true"}}, state: docker.State{Running: false}},
 	}
 	dockerServer, containers := s.startDockerServer(bogusContainers, nil, c)
 	defer dockerServer.Stop()
@@ -99,9 +101,10 @@ func (s S) TestReportStatus(c *check.C) {
 	c.Assert(err, check.IsNil)
 	ids := make([]string, len(apiContainers))
 	for i, cont := range apiContainers {
+		println(cont.ID)
 		ids[i] = cont.ID
 	}
-	expectedIDs := []string{containers[0].ID, containers[1].ID, containers[2].ID, containers[4].ID, containers[5].ID}
+	expectedIDs := []string{containers[0].ID, containers[1].ID, containers[2].ID, containers[4].ID, containers[5].ID, containers[6].ID, containers[7].ID}
 	sort.Strings(ids)
 	sort.Strings(expectedIDs)
 	c.Assert(ids, check.DeepEquals, expectedIDs)

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -47,11 +47,12 @@ func (s S) TestReportStatus(c *check.C) {
 		{name: "x6", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}}, state: docker.State{Running: false}},
 		{name: "x7", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}, Labels: map[string]string{"is-isolated-run": "true"}}, state: docker.State{Running: true}},
 		{name: "x8", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}, Labels: map[string]string{"is-isolated-run": "true"}}, state: docker.State{Running: false}},
+		{name: "x9", config: docker.Config{Image: "tsuru/python", Env: []string{"HOME=/", "TSURU_APPNAME=someapp"}, Labels: map[string]string{"is-isolated-run": "false"}}, state: docker.State{Running: true}},
 	}
 	dockerServer, containers := s.startDockerServer(bogusContainers, nil, c)
 	defer dockerServer.Stop()
-	result := `[{"id":"%s","found":true},{"id":"%s","found":true},{"id":"%s","found":true},{"id":"%s","found":false},{"id":"%s","found":true}]`
-	buf := bytes.NewBufferString(fmt.Sprintf(result, containers[0].ID, containers[1].ID, containers[2].ID, containers[3].ID, containers[5].ID))
+	result := `[{"id":"%s","found":true},{"id":"%s","found":true},{"id":"%s","found":true},{"id":"%s","found":false},{"id":"%s","found":true},{"id":"%s","found":true}]`
+	buf := bytes.NewBufferString(fmt.Sprintf(result, containers[0].ID, containers[1].ID, containers[2].ID, containers[3].ID, containers[5].ID, containers[8].ID))
 	var resp http.Response
 	resp.StatusCode = http.StatusOK
 	resp.Body = ioutil.NopCloser(buf)
@@ -81,6 +82,7 @@ func (s S) TestReportStatus(c *check.C) {
 			{ID: containers[2].ID, Status: "error", Name: "x3"},
 			{ID: containers[3].ID, Status: "started", Name: "x4"},
 			{ID: containers[5].ID, Status: "created", Name: "x6"},
+			{ID: containers[8].ID, Status: "started", Name: "x9"},
 		},
 	}
 	var input hostStatus
@@ -104,7 +106,7 @@ func (s S) TestReportStatus(c *check.C) {
 		println(cont.ID)
 		ids[i] = cont.ID
 	}
-	expectedIDs := []string{containers[0].ID, containers[1].ID, containers[2].ID, containers[4].ID, containers[5].ID, containers[6].ID, containers[7].ID}
+	expectedIDs := []string{containers[0].ID, containers[1].ID, containers[2].ID, containers[4].ID, containers[5].ID, containers[6].ID, containers[7].ID, containers[8].ID}
 	sort.Strings(ids)
 	sort.Strings(expectedIDs)
 	c.Assert(ids, check.DeepEquals, expectedIDs)


### PR DESCRIPTION
BS reports the status of all containers with the TSURU_APPNAME env. This is fine for most cases, except for isolated containers (those created by `tsuru app-run -i` or `tsuru app-shell -i`), since they are not registered as a container on Tsuru. This causes the removal of the container after some time.

Tsuru already puts the label `is-isolated-run`, which identifies a container as isolated. All BS have to do is ignore those containers and don't report then to Tsuru.