### PR TITLE
hostcheck: add forceError check to force check fail on host

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ host. If the check takes more than the time specified in this environment
 variable, the check will be considered a failure. The default value is `0`,
 which means no timeout.
 
+### HOSTCHECK_KIND_FILTER
+
+`HOSTCHECK_KIND_FILTER` is a comma separated list of checks which BS will attempt
+before declare host as failure. Default values set to `"writablePath, forceError, createContainer`
+
 ## Injected Environment Variables
 
 Tsuru will inject some environment variables when starting the bs container.

--- a/status/hostcheck.go
+++ b/status/hostcheck.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -123,10 +123,7 @@ func (c *writableCheck) Name() string {
 }
 
 func (c *writableCheck) Run() error {
-	fileName := strings.Join([]string{
-		strings.TrimRight(c.path, string(os.PathSeparator)),
-		"tsuru-bs-ro.check",
-	}, string(os.PathSeparator))
+	fileName := filepath.Join(c.path, "tsuru-bs-ro.check")
 	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0660)
 	if err != nil {
 		return err
@@ -158,10 +155,7 @@ func (c *forceErrorCheck) Name() string {
 }
 
 func (c *forceErrorCheck) Run() error {
-	fileName := strings.Join([]string{
-		strings.TrimRight(c.path, string(os.PathSeparator)),
-		"tsuru-bs-host-fail.check",
-	}, string(os.PathSeparator))
+	fileName := filepath.Join(c.path, "tsuru-bs-host-fail.check")
 	info, err := os.Stat(fileName)
 	if err == nil && !info.IsDir() {
 		return fmt.Errorf("path \"%s\" to force host fail found", fileName)

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -88,7 +88,7 @@ func (s S) TestReportStatus(c *check.C) {
 	var input hostStatus
 	err = form.DecodeString(&input, string(req.body))
 	c.Assert(err, check.IsNil)
-	c.Assert(input.Checks, check.HasLen, 2)
+	c.Assert(input.Checks, check.HasLen, 3)
 	c.Assert(len(input.Addrs) > 0, check.Equals, true)
 	input.Checks = nil
 	input.Addrs = nil


### PR DESCRIPTION
Sometimes we want that BS fails while host overall is healthy. This adds a new `forceError` check mechanism to hostcheck collection to force it. 